### PR TITLE
Fixing call to missing method

### DIFF
--- a/PHPUnit/Extensions/Progress/ResultPrinter.php
+++ b/PHPUnit/Extensions/Progress/ResultPrinter.php
@@ -247,7 +247,7 @@ class PHPUnit_Extensions_Progress_ResultPrinter extends PHPUnit_TextUI_ResultPri
     );
 
     if ( $result->wasSuccessful() &&
-      $result->allCompletlyImplemented() &&
+	  $result->allCompletelyImplemented() &&
       $result->noneSkipped() )
     {
       $this->write($this->green($footer));


### PR DESCRIPTION
PHP Fatal error: Call to undefined method
PHPUnit_Framework_TestResult::allCompletlyImplemented()

Lodged as an issue here:
https://github.com/Maher4Ever/guard-phpunit/issues/10
