### PR TITLE
Fixed spelling error in line 250 that was causing ResultPrinter.php to return incorrect test status

### DIFF
--- a/PHPUnit/Extensions/Progress/ResultPrinter.php
+++ b/PHPUnit/Extensions/Progress/ResultPrinter.php
@@ -247,7 +247,7 @@ class PHPUnit_Extensions_Progress_ResultPrinter extends PHPUnit_TextUI_ResultPri
     );
 
     if ( $result->wasSuccessful() &&
-      $result->allCompletlyImplemented() &&
+      $result->allCompletelyImplemented() &&
       $result->noneSkipped() )
     {
       $this->write($this->green($footer));


### PR DESCRIPTION
...ngs to display that passed tests are failing.

Changed $result->allCompletlyImplemented()  to  $result->allCompletelyImplemented()
